### PR TITLE
Fixes Armour Abilities

### DIFF
--- a/code/modules/halo/clothing/spartan_armour.dm
+++ b/code/modules/halo/clothing/spartan_armour.dm
@@ -73,7 +73,7 @@
 	..()
 
 	spawn(0)
-		if(user && user.client && specials.len <= 2 && available_abilities.len)
+		if(user && user.client && specials.len <= 3 && available_abilities.len)
 			var/ability_type_string = input(user, "Choose the armour ability of your MJOLNIR","MJOLNIR Armour Ability") in available_abilities
 			var/ability_type = available_abilities[ability_type_string]
 			specials.Add(new ability_type(src))


### PR DESCRIPTION
Fixes Armour abilities not showing up on Spartan spawn by changing e maximum amount of armour abilities allowed from 2 to 3 (both shielding itself and shieldmonitor count as AAs in the code)

