### PR TITLE
Sting spartanchanges

### DIFF
--- a/code/modules/halo/clothing/spartan_armour.dm
+++ b/code/modules/halo/clothing/spartan_armour.dm
@@ -60,7 +60,10 @@
 	allowed = list(/obj/item/weapon/tank)
 	totalshields = 150
 	item_state_slots = list(slot_l_hand_str = "syndicate-black", slot_r_hand_str = "syndicate-black")
-	var/list/available_abilities = list(\
+	var/list/available_abilities = list()
+
+/obj/item/clothing/suit/armor/special/spartan/AA
+	available_abilities = list(	\
 		"Hologram Decoy Emitter" = /datum/armourspecials/holo_decoy,\
 		"Personal Cloaking Device" = /datum/armourspecials/cloaking/limited,\
 		"Personal Regeneration Field" = /datum/armourspecials/regeneration,\

--- a/maps/ONI_Prowler/jobs.dm
+++ b/maps/ONI_Prowler/jobs.dm
@@ -2,8 +2,8 @@
 	title = "Spartan II"
 	spawn_faction = "UNSC"
 	outfit_type = /decl/hierarchy/outfit/onispartan
-	total_positions = 3
-	spawn_positions = 4
+	total_positions = 0
+	spawn_positions = 0
 	account_allowed = 0
 	is_whitelisted = 1
 	economic_modifier = 1.0
@@ -15,12 +15,22 @@
 	loadout_allowed = TRUE
 	lace_access = TRUE
 
+/datum/job/ONI_Spartan_II/equip()
+	. = ..()
+	var/player_pop = 0
+	for(var/client/C in GLOB.clients)
+		if(!C.mob)
+			continue
+		player_pop++
+	var/datum/job/to_modify = job_master.occupations_by_type[type]
+	to_modify.total_positions = min(round(player_pop/10),3)
+
 /datum/job/ONI_Spartan_II_Commander
 	title = "Spartan II Commander"
 	spawn_faction = "UNSC"
 	outfit_type = /decl/hierarchy/outfit/onispartan
 	total_positions = 1
-	spawn_positions = 4
+	spawn_positions = 1
 	account_allowed = 0
 	is_whitelisted = 1
 	economic_modifier = 1.0
@@ -31,3 +41,13 @@
 	latejoin_at_spawnpoints = 1
 	loadout_allowed = TRUE
 	lace_access = TRUE
+
+/datum/job/ONI_Spartan_II/equip()
+	. = ..()
+	var/player_pop = 0
+	for(var/client/C in GLOB.clients)
+		if(!C.mob)
+			continue
+		player_pop++
+	var/datum/job/to_modify = job_master.occupations_by_type[/datum/job/ONI_Spartan_II]
+	to_modify.total_positions = min(round(player_pop/10),3)

--- a/maps/ccs_battlecruiser/jobs/spartan.dm
+++ b/maps/ccs_battlecruiser/jobs/spartan.dm
@@ -29,7 +29,7 @@
 /decl/hierarchy/outfit/spartan_two_oprf
 	name = "OPRF Spartan II"
 	uniform = /obj/item/clothing/under/spartan_internal
-	suit = /obj/item/clothing/suit/armor/special/spartan
+	suit = /obj/item/clothing/suit/armor/special/spartan/AA
 	belt = /obj/item/weapon/storage/belt/marine_ammo
 	shoes = /obj/item/clothing/shoes/magboots/spartan
 	gloves = /obj/item/clothing/gloves/spartan


### PR DESCRIPTION
commander job is always available without pop check. spawing into commander job triggers popcheck and adjusts other spartan jobs accordingly. further spawning into spartan jobs will modify the available jobslots.